### PR TITLE
ci: add step to free up disk space in GitHub Actions workflow

### DIFF
--- a/.github/workflows/app.yaml
+++ b/.github/workflows/app.yaml
@@ -66,6 +66,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.release.output.version }}
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # Remove large packages that aren't needed for Docker builds
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
- Add jlumbroso/free-disk-space action to remove unnecessary packages
- Frees up ~20-30GB by removing tool cache, Android SDK, .NET, Haskell, and large packages
- Resolves 'No space left on device' error when building CUDA Docker images
- Keeps Docker images and swap storage for build process